### PR TITLE
Update to 7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ but you can also run it in a Mix-and-Match style, which we'll decribe below.
 
 ## Running the application with Docker
 
-You will need [Docker](https://docs.docker.com/get-docker/) installed on your machine in order to run this application as we have defined a [_Dockerfile_](Dockerfile) and a [_docker-compose.yml_](docker-compose.yml) to run Couchbase Server 7.0.0 beta, the front-end [Vue app](https://github.com/couchbaselabs/try-cb-frontend-v2.git) and the .NET REST API.
+You will need [Docker](https://docs.docker.com/get-docker/) installed on your machine in order to run this application as we have defined a [_Dockerfile_](Dockerfile) and a [_docker-compose.yml_](docker-compose.yml) to run Couchbase Server 7.0.0, the front-end [Vue app](https://github.com/couchbaselabs/try-cb-frontend-v2.git) and the .NET REST API.
 
 To launch the full application, simply run this command from a terminal:
 
     docker-compose up
 
-> **_NOTE:_** When you run the application for the first time, it will pull/build the relevant docker images, so it might take a bit of time.
+> **_NOTE:_** You may need more than the default RAM to run the images.
+We have tested the travel-sample apps with 4.5 GB RAM configured in Docker's Preferences... -> Resources -> Memory.
+When you run the application for the first time, it will pull/build the relevant docker images, so it might take a bit of time.
 
-This will start the .NET backend, Couchbase Server 7.0.0-beta and the Vue frontend app.
+This will start the .NET backend, Couchbase Server 7.0.0 and the Vue frontend app.
 
 You can access the backend API on http://localhost:8080/, the UI on
 http://localhost:8081/ and Couchbase Server at http://localhost:8091/
@@ -39,20 +41,20 @@ http://localhost:8081/ and Couchbase Server at http://localhost:8091/
     ❯ docker-compose up
 
     Creating network "try-cb-dotnet_default" with the default driver
-    Creating couchbase-sandbox-7.0.0-beta ... done
+    Creating couchbase-sandbox-7.0.0      ... done
     Creating try-cb-api                   ... done
     Creating try-cb-fe                    ... done
-    Attaching to couchbase-sandbox-7.0.0-beta, try-cb-api, try-cb-fe
-    couchbase-sandbox-7.0.0-beta | Starting Couchbase Server -- Web UI available at http://<ip>:8091
-    couchbase-sandbox-7.0.0-beta | and logs available in /opt/couchbase/var/lib/couchbase/logs
-    couchbase-sandbox-7.0.0-beta | Configuring Couchbase Server.  Please wait (~60 sec)...
-    couchbase-sandbox-7.0.0-beta | Configuration completed!
+    Attaching to couchbase-sandbox-7.0.0, try-cb-api, try-cb-fe
+    couchbase-sandbox-7.0.0 | Starting Couchbase Server -- Web UI available at http://<ip>:8091
+    couchbase-sandbox-7.0.0 | and logs available in /opt/couchbase/var/lib/couchbase/logs
+    couchbase-sandbox-7.0.0 | Configuring Couchbase Server.  Please wait (~60 sec)...
+    couchbase-sandbox-7.0.0 | Configuration completed!
     try-cb-api  | wait-for-couchbase: checking http://db:8091/pools/default/buckets/travel-sample/
     try-cb-api  | wait-for-couchbase: polling for '.scopes | map(.name) | contains(["inventory", "
     try-cb-api  | wait-for-couchbase: checking http://db:8094/api/cfg
     try-cb-api  | wait-for-couchbase: polling for '.status == "ok"'
-    couchbase-sandbox-7.0.0-beta | Couchbase Admin UI: http://localhost:8091
-    couchbase-sandbox-7.0.0-beta | Login credentials: Administrator / password
+    couchbase-sandbox-7.0.0 | Couchbase Admin UI: http://localhost:8091
+    couchbase-sandbox-7.0.0 | Login credentials: Administrator / password
     try-cb-api  | wait-for-couchbase: checking http://db:8094/api/index/hotels-index
     try-cb-api  | wait-for-couchbase: polling for '.status == "ok"'
     try-cb-api  | wait-for-couchbase: Failure
@@ -103,7 +105,7 @@ alternative `mix-and-match.yml`. We'll look at a few useful scenarios here.
 ### Bring your own database
 
 If you wish to run this application against your own configuration of Couchbase
-Server, you will need version 7.0.0 beta or later with the `travel-sample`
+Server, you will need version 7.0.0 or later with the `travel-sample`
 bucket setup.
 
 > **_NOTE:_** if you are not using Docker to start up the API server, or the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       entrypoint: ["wait-for-it", "backend:8080", "--timeout=0", "--", "npm", "run", "serve"]
 
   db:
-    image: couchbase/server-sandbox:7.0.0-beta
+    image: couchbase/server-sandbox:7.0.0
     ports:
       - "8091-8095:8091-8095"
       - "11210:11210"
@@ -45,4 +45,4 @@ services:
       interval: 20s
       timeout: 20s
       retries: 2
-    container_name: couchbase-sandbox-7.0.0-beta
+    container_name: couchbase-sandbox-7.0.0

--- a/mix-and-match.yml
+++ b/mix-and-match.yml
@@ -18,7 +18,7 @@ services:
     container_name: try-cb-fe-mm
 
   db:
-    image: couchbase/server-sandbox:7.0.0-beta
+    image: couchbase/server-sandbox:7.0.0
     ports:
       - "8091-8095:8091-8095"
       - "9102:9102"
@@ -31,4 +31,4 @@ services:
       - "8095"
       - "9102"
       - "11210"
-    container_name: couchbase-sandbox-7.0.0-beta-mm
+    container_name: couchbase-sandbox-7.0.0-mm

--- a/wait-for-couchbase.sh
+++ b/wait-for-couchbase.sh
@@ -3,9 +3,9 @@
 
 set -e
 
-CB_HOST="${CB_HOST:-db}"
-CB_USER="${CB_USER:-Administrator}"
-CB_PSWD="${CB_PSWD:-password}"
+export CB_HOST="${CB_HOST:-db}"
+export CB_USER="${CB_USER:-Administrator}"
+export CB_PSWD="${CB_PSWD:-password}"
 
 
 #### Utility Functions ####


### PR DESCRIPTION
Point to GA
Export CB_ variables to make sure we point at `db` on docker-compose up
Note memory requirements