### PR TITLE
Add default page

### DIFF
--- a/try-cb-dotnet/Startup.cs
+++ b/try-cb-dotnet/Startup.cs
@@ -73,6 +73,8 @@ namespace try_cb_dotnet
             });
 
             app.UseAuthorization();
+            
+            app.UseDefaultFiles();
             app.UseStaticFiles();
 
             app.UseEndpoints(endpoints =>

--- a/try-cb-dotnet/wwwroot/index.html
+++ b/try-cb-dotnet/wwwroot/index.html
@@ -1,0 +1,6 @@
+<h1>.NET Travel Sample API</h1>
+    A sample API for getting started with Couchbase Server and the .NET SDK.
+    <ul>
+        <li><a href="/apidocs">Learn the API with Swagger, interactively</a>
+        <li><a href="https://github.com/couchbaselabs/try-cb-dotnet">GitHub</a>
+    </ul>


### PR DESCRIPTION
Reported by David Elliott, thanks!

  localhost:8080/

Now gives a bare HTML page with links to the apidocs, as per other sample apps.